### PR TITLE
Add packaging attributes & autoload

### DIFF
--- a/tla-mode.el
+++ b/tla-mode.el
@@ -155,6 +155,10 @@
   (prettify-symbols-mode)  
   )
 
+;;;###autoload
+(add-to-list 'auto-mode-alist
+             '("\\.tla\\'" . tla-mode))
+
 (provide 'tla-mode)
 
 ;;; tla-mode.el ends here

--- a/tla-mode.el
+++ b/tla-mode.el
@@ -1,6 +1,13 @@
-;; TLA mode
+;;; tla-mode.el --- TLA+ language support for Emacs
+
+;; Copyright (C) 2015-2016 Ratish Punnoose
+
 ;; Author: Ratish Punnoose
-;;
+;; Version: 1.0
+;; URL: https://github.com/ratish-punnoose/tla-mode
+;; Created: 8 Jun 2015
+
+;;; Code:
 
 (defvar tla-mode-map
    (let ((map (make-sparse-keymap)))
@@ -61,6 +68,7 @@
      )))
 
 
+;;;###autoload
 (define-derived-mode tla-mode prog-mode "TLA"
   "TLA mode is a major mode for writing TLA+ specifications"
   :syntax-table tla-mode-syntax-table
@@ -148,3 +156,5 @@
   )
 
 (provide 'tla-mode)
+
+;;; tla-mode.el ends here


### PR DESCRIPTION
Emacs didn't recognize tla-mode as a package, so this this adds some required headers in the comments. Now the package gets loaded automatically as well.

With these two changes, you can install tla-mode easily with, for example, [quelpa](https://github.com/quelpa/quelpa#installing-with-a-recipe). And you could add it to MELPA if you want to!
