### PR TITLE
Fix single line comment terminator

### DIFF
--- a/tla-mode.el
+++ b/tla-mode.el
@@ -248,7 +248,7 @@
 
     ;; /* is a comment
     (modify-syntax-entry ?\\ ". 12b" st)
-    (modify-syntax-entry ?\n "> b" st)
+    (modify-syntax-entry ?\n ">" st)
     ; Return st
     st
     )


### PR DESCRIPTION
Closes #6 

IIUC, the `b` qualifier on the single line comment delimiter is
misplaced, since, according to the
docs (https://www.gnu.org/software/emacs/manual/html_node/elisp/Syntax-Flags.html)

> For a two-character comment starter, this flag is only significant on
> the second char, and for a 2-character comment ender it is only
> significant on the first char.

But the new line terminator for single line comments is neither of these
cases.

I could well be mistaken here, as this is my first time looking at the emacs syntax table (what a weird way to specify the comment markers!?), but this seems to be fixing the problem reported on #6 on my machine.